### PR TITLE
Feature/replace express graphql

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,6 +1,6 @@
 import express from 'express';
 import cors from 'cors';
-import { graphqlHTTP } from 'express-graphql';
+import { createHandler } from 'graphql-http/lib/use/express';
 import { buildSchema } from 'graphql';
 import { getData, addTask, removeTask } from './lib/redis.mjs';
 
@@ -82,7 +82,7 @@ const rootValue = {
 
 app.use(
  '/graphql',
- graphqlHTTP({
+ createHandler({
    schema,
    rootValue,
    graphiql: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "express-graphql": "^0.12.0",
         "graphql": "^16.6.0",
+        "graphql-http": "^1.9.0",
         "redis": "^4.5.1"
       },
       "devDependencies": {
@@ -365,62 +365,6 @@
         "node": ">= 0.10.0"
       }
     },
-    "node_modules/express-graphql": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/express-graphql/-/express-graphql-0.12.0.tgz",
-      "integrity": "sha512-DwYaJQy0amdy3pgNtiTDuGGM2BLdj+YO2SgbKoLliCfuHv3VVTt7vNG/ZqK2hRYjtYHE2t2KB705EU94mE64zg==",
-      "dependencies": {
-        "accepts": "^1.3.7",
-        "content-type": "^1.0.4",
-        "http-errors": "1.8.0",
-        "raw-body": "^2.4.1"
-      },
-      "engines": {
-        "node": ">= 10.x"
-      },
-      "peerDependencies": {
-        "graphql": "^14.7.0 || ^15.3.0"
-      }
-    },
-    "node_modules/express-graphql/node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/express-graphql/node_modules/http-errors": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
-      "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/express-graphql/node_modules/statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/express-graphql/node_modules/toidentifier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -524,6 +468,17 @@
       "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-http": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.9.0.tgz",
+      "integrity": "sha512-MMwhHK24BRzf/AODYnT7eu3eCFHzoj1LBeB/8j+pFuhk539bnYQLP8Z/ey92PEgAbbL28lml7uZXbbCDYHVM1A==",
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
       }
     },
     "node_modules/has": {
@@ -1402,46 +1357,6 @@
         "vary": "~1.1.2"
       }
     },
-    "express-graphql": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/express-graphql/-/express-graphql-0.12.0.tgz",
-      "integrity": "sha512-DwYaJQy0amdy3pgNtiTDuGGM2BLdj+YO2SgbKoLliCfuHv3VVTt7vNG/ZqK2hRYjtYHE2t2KB705EU94mE64zg==",
-      "requires": {
-        "accepts": "^1.3.7",
-        "content-type": "^1.0.4",
-        "http-errors": "1.8.0",
-        "raw-body": "^2.4.1"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-          "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="
-        },
-        "http-errors": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
-          "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
-          "requires": {
-            "depd": "~1.1.2",
-            "inherits": "2.0.4",
-            "setprototypeof": "1.2.0",
-            "statuses": ">= 1.5.0 < 2",
-            "toidentifier": "1.0.0"
-          }
-        },
-        "statuses": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-          "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="
-        },
-        "toidentifier": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-          "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
-        }
-      }
-    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -1515,6 +1430,12 @@
       "version": "16.6.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
       "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw=="
+    },
+    "graphql-http": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.9.0.tgz",
+      "integrity": "sha512-MMwhHK24BRzf/AODYnT7eu3eCFHzoj1LBeB/8j+pFuhk539bnYQLP8Z/ey92PEgAbbL28lml7uZXbbCDYHVM1A==",
+      "requires": {}
     },
     "has": {
       "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "server",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "server",
-      "version": "0.2.4",
+      "version": "0.3.0",
       "license": "ISC",
       "dependencies": {
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "express-graphql": "^0.12.0",
     "graphql": "^16.6.0",
+    "graphql-http": "^1.9.0",
     "redis": "^4.5.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "",
   "main": "index.mjs",
   "scripts": {


### PR DESCRIPTION
### Changes

- Replaced `express-graphql` with `graphq-http` library as the first was deprecated